### PR TITLE
Migrate away from eventuate to tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 byteorder = "1.4"
 crc = "3"
-eventual = "0.1.4"
+tokio = { version = "1.21.2", features = ["rt-multi-thread", "fs", "macros"] }
 fs2 = "0.4"
 log = "0.4"
 memmap = "0.5.2"

--- a/examples/wal.rs
+++ b/examples/wal.rs
@@ -1,4 +1,5 @@
 use std::env;
+use tokio::runtime::Runtime;
 
 use wal::Wal;
 
@@ -6,7 +7,8 @@ fn main() {
     env_logger::init();
     let path = env::args().nth(1).unwrap_or_else(|| ".".to_owned());
     println!("path: {}", path);
-    let mut wal = Wal::open(&path).unwrap();
+    let runtime = Runtime::new().unwrap();
+    let mut wal = Wal::open(&path, runtime.handle().clone()).unwrap();
 
     let entry: &[u8] = &[42u8; 4096];
 

--- a/src/bin/wal-ctl.rs
+++ b/src/bin/wal-ctl.rs
@@ -4,6 +4,7 @@ use std::process;
 
 use docopt::Docopt;
 use serde::Deserialize;
+use tokio::runtime::{Handle, Runtime};
 use wal::Wal;
 
 static USAGE: &str = "
@@ -63,7 +64,10 @@ fn main() {
         process::exit(1);
     }
 
-    let wal = open_wal(&path);
+    let runtime = Runtime::new().unwrap();
+    let runtime_handle = runtime.handle().clone();
+
+    let wal = open_wal(&path, runtime_handle);
 
     if args.cmd_check {
         check(wal);
@@ -77,8 +81,8 @@ fn main() {
     }
 }
 
-fn open_wal(path: &Path) -> Wal {
-    Wal::open(path).unwrap_or_else(|error| {
+fn open_wal(path: &Path, runtime_handle: Handle) -> Wal {
+    Wal::open(path, runtime_handle).unwrap_or_else(|error| {
         eprintln!(
             "Unable to open write ahead log in directory {:?}: {}.",
             path, error

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -406,7 +406,7 @@ impl Segment {
                 String::new()
             };
 
-            let handle = runtime.spawn(async move {
+            let handle = runtime.spawn_blocking(move || {
                 debug!("{}", log_msg);
                 view.restrict(start, end - start).and_then(|_| view.flush())
             });


### PR DESCRIPTION
This PR tackles https://github.com/qdrant/wal/issues/23

All tests are passing but I am not sure this is the best approach. 

Maybe it is possible to get this done with only the `futures` crate?

Previously, a thread was created to run the flush and then propagate its result through a promise.

In this PR we use a Tokio Task to run the flush and capture its handle.

The remaining concern is that the logic are now entirely equivalent see https://github.com/qdrant/wal/pull/32#discussion_r1009104194
