### PR TITLE
Data loss truncation drop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -978,7 +978,7 @@ mod test {
         assert_eq!(wal.closed_segments[2].segment.len(), 1); // 4 empty slot due to truncation
         assert_eq!(wal.closed_segments[3].segment.len(), 2); // 5, 6
         assert_eq!(wal.closed_segments[4].segment.len(), 2); // 7, 8
-        assert_eq!(wal.open_segment.segment.len(), 1);       // 9
+        assert_eq!(wal.open_segment.segment.len(), 1); // 9
 
         eprintln!("wal: {:?}", wal);
         eprintln!("wal open: {:?}", wal.open_segment);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -939,6 +939,10 @@ mod test {
         assert_eq!(wal.closed_segments[3].segment.len(), 2);
         assert_eq!(wal.open_segment.segment.len(), 2); // 1 x 2 entries
 
+        wal.truncate(9).unwrap();
+
+        assert_eq!(wal.open_segment.segment.len(), 1); // 1 x 2 entries
+
         // truncate half of it
         wal.truncate(5).unwrap();
 
@@ -959,7 +963,7 @@ mod test {
         assert_eq!(wal.closed_segments[2].segment.len(), 1);
         assert_eq!(wal.open_segment.segment.len(), 0); // empty open segment
 
-        // add 10 more entries
+        // add 5 more entries
         for i in 0..5 {
             assert_eq!(i + 5, wal.append(&&entry[..]).unwrap());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -969,6 +969,24 @@ mod test {
         assert_eq!(wal.first_index(), 0);
         assert_eq!(wal.last_index(), 9);
         assert_eq!(wal.closed_segments.len(), 5);
+        assert_eq!(wal.closed_segments[0].segment.len(), 2); // 1,2
+        assert_eq!(wal.closed_segments[1].segment.len(), 2); // 3
+        assert_eq!(wal.closed_segments[2].segment.len(), 1); // 4 empty slot due to truncation
+        assert_eq!(wal.closed_segments[3].segment.len(), 2); // 5, 6
+        assert_eq!(wal.closed_segments[4].segment.len(), 2); // 7, 8
+        assert_eq!(wal.open_segment.segment.len(), 1);       // 9
+
+        eprintln!("wal: {:?}", wal);
+        eprintln!("wal open: {:?}", wal.open_segment);
+        eprintln!("wal closed: {:?}", wal.closed_segments);
+
+        // test persistence
+        drop(wal);
+        let wal = Wal::open(dir.path()).unwrap();
+        assert_eq!(wal.num_entries(), 10);
+        assert_eq!(wal.first_index(), 0);
+        assert_eq!(wal.last_index(), 9);
+        assert_eq!(wal.closed_segments.len(), 5);
         assert_eq!(wal.closed_segments[0].segment.len(), 2);
         assert_eq!(wal.closed_segments[1].segment.len(), 2);
         assert_eq!(wal.closed_segments[2].segment.len(), 1); // previously half truncated

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -361,7 +361,8 @@ impl Segment {
         trace!("{:?}: truncating from position {}", self, from);
 
         // Remove the index entries.
-        let _ = self.index.drain(from..);
+        let deleted = self.index.drain(from..).count();
+        trace!("{:?}: truncated {} entries", self, deleted);
 
         // And overwrite the existing data so that we will not read the data back after a crash.
         let size = self.size();
@@ -376,7 +377,10 @@ impl Segment {
         let end = self.size();
 
         match start.cmp(&end) {
-            Ordering::Equal => Ok(()), // nothing to flush
+            Ordering::Equal => {
+                debug!("{:?}: nothing to flush", self);
+                Ok(())
+            }, // nothing to flush
             Ordering::Less => {
                 // flush new elements added since last flush
                 debug!("{:?}: flushing byte range [{}, {})", self, start, end);

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -1,4 +1,4 @@
-use log::{debug, error, info, log_enabled, trace};
+use log::{debug, error, log_enabled, trace};
 use std::cmp::Ordering;
 use std::fmt;
 use std::fs::{self, OpenOptions};

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -250,10 +250,15 @@ impl Segment {
                 let mut digest = CASTAGNOLI.digest_with_initial(crc);
                 digest.update(&segment[offset..offset + HEADER_LEN + padded_len]);
                 let entry_crc = digest.finalize();
-                let stored_crc = LittleEndian::read_u32(&segment[offset + HEADER_LEN + padded_len..]);
-                if entry_crc != stored_crc
-                {
-                    log::warn!("CRC mismatch at offset {}: {} != {}", offset, entry_crc, stored_crc);
+                let stored_crc =
+                    LittleEndian::read_u32(&segment[offset + HEADER_LEN + padded_len..]);
+                if entry_crc != stored_crc {
+                    log::warn!(
+                        "CRC mismatch at offset {}: {} != {}",
+                        offset,
+                        entry_crc,
+                        stored_crc
+                    );
                     break;
                 }
 
@@ -401,7 +406,7 @@ impl Segment {
             Ordering::Equal => {
                 debug!("{:?}: nothing to flush", self);
                 Ok(())
-            }, // nothing to flush
+            } // nothing to flush
             Ordering::Less => {
                 // flush new elements added since last flush
                 debug!("{:?}: flushing byte range [{}, {})", self, start, end);


### PR DESCRIPTION
So the problem was the following:

1. There is a CRC checksum that is calculated for each record in "blockchain" manner, previous checksum is used as a need for the next one. First seed is random and stored in WAL Segment.
2. For the convenience, we have a `self.crc` field, which have the most recent CRC (CRC of the last segment)
3. On truncation, we update everything on disk, but didn't update `self.crc`, it was still holding the CRC of truncated record.
4. If WAL was reloaded from disk after truncation, everything worked fine, but if somebody would try to write some data into this open truncated segment, the following CRC record would be incorrect.
5. Records with invalid CRC was ignored on load.

------

The moral of the story:

- having multiple source-of-truth in the system is error-prone, even if it is the simple crc u32 value.
- handling checksum errors by simply ignoring entries - is not the best strategy.

P.S.

All credits for finding this _critical_ bug goes to @agourlay, after it was located, fixing was a fairly simple mechanical task.
