### PR TITLE
Windows specific fixes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,10 @@ env:
 jobs:
   build:
     name: Rust CI
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v3
       - name: Check code formatting

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -165,6 +165,13 @@ impl Segment {
                 segment[3] = SEGMENT_VERSION;
                 LittleEndian::write_u32(&mut segment[4..], seed);
             }
+
+            // Manually sync each file in Windows since sync-ing cannot be done for the whole directory.
+            #[cfg(target_os = "windows")]
+            {
+                mmap.flush()?;
+                file.sync_all()?;
+            }
         };
 
         // File renames are atomic, so we can safely rename the temporary file to the final file.
@@ -561,8 +568,57 @@ impl Segment {
     /// Deletes the segment file.
     pub fn delete(self) -> Result<()> {
         debug!("{:?}: deleting file", self);
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            self.delete_unix()
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            self.delete_windows()
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn delete_unix(self) -> Result<()> {
         fs::remove_file(&self.path).map_err(|e| {
             error!("{:?}: failed to delete segment {}", self, e);
+            e
+        })
+    }
+
+    #[cfg(target_os = "windows")]
+    fn delete_windows(self) -> Result<()> {
+        let Segment {
+            mmap,
+            path,
+            index,
+            flush_offset,
+            ..
+        } = self;
+        let mmap_len = mmap.len();
+
+        // Unmaps the file before `fs::remove_file` else access will be denied
+        let _ = mmap.flush();
+        std::mem::drop(mmap);
+
+        fs::remove_file(&path).map_err(|e| {
+            error!(
+                "{:?}: failed to delete segment {}",
+                // `self` was destructured when mmap was yoinked out so `fmt::Debug` cannot be used
+                format_args!(
+                    "Segment {{ path: {:?}, flush_offset: {}, entries: {}, space: ({}/{}) }}",
+                    path,
+                    flush_offset,
+                    index.len(),
+                    index.last().map_or(HEADER_LEN, |&(offset, len)| {
+                        offset + len + padding(len) + CRC_LEN
+                    }),
+                    mmap_len
+                ),
+                e
+            );
             e
         })
     }


### PR DESCRIPTION
Bunch of ugly hacks to make the crate work on Windows. Only run tests on `wal` so I don't know if this fixes qdrant/qdrant#1220.

Originally learned of the bug because of a [job listing in Upwork](https://www.upwork.com/jobs/~0194457eb1cd7913ec). They haven't checked in for the last 2 weeks and this is just sitting on my hard drive for just as long so might as well submit it sooner than later.