### PR TITLE
Replace the fs2 crate, which is no longer maintained, with rustix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,14 @@ edition = "2021"
 [dependencies]
 byteorder = "1.4"
 crc = "3"
-fs2 = "0.4"
 log = "0.4"
 memmap2 = "0.5.10"
 rand = "0.8.5"
 rand_distr = "0.4.3"
+fs4 = "0.6"
+# fs4 depends on rustix, but pulling this dependency explicitly into the tree
+# to use direct functions on FreeBSD
+rustix = { version = "0", features = [ "fs" ]}
 crossbeam-channel = "0.5.7"
 
 # Binary dependencies

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use crossbeam_channel::{Receiver, Sender};
-use fs2::FileExt;
+use fs4::FileExt;
 use log::{debug, info, trace, warn};
 use std::cmp::Ordering;
 use std::fmt;
@@ -1027,7 +1027,7 @@ mod test {
         let dir = Builder::new().prefix("wal").tempdir().unwrap();
         let wal = Wal::open(dir.path()).unwrap();
         assert_eq!(
-            fs2::lock_contended_error().kind(),
+            fs4::lock_contended_error().kind(),
             Wal::open(dir.path()).unwrap_err().kind()
         );
         drop(wal);


### PR DESCRIPTION
This change originally started with some qdrant test failures on FreeBSD/ZFS because posix_fallocate returns `EINVAL` when attempting to create a sparse file on a copy-on-write filesystem. While investigating I found that this repository relied on fs2 which is no longer maintained. There is an [fs4](https://github.com/al8n/fs4-rs) crate which
continues development, but is working to replace use of the `libc` crate with `rustix`.

In theory `wal` should just be able to go straight to Rustix for these few API calls, and keep the compile/link times down for qdrant as a whole.