### PR TITLE
flush tmp segment before renaming into a permanent one

### DIFF
--- a/src/segment.rs
+++ b/src/segment.rs
@@ -174,10 +174,14 @@ impl Segment {
                 LittleEndian::write_u32(&mut segment[4..], seed);
             }
 
+            // From "man 2 close":
+            // > A successful close does not guarantee that the data has been successfully saved to disk, as the kernel defers writes.
+            // So we need to flush magic header manually to ensure that it is written to disk.
+            mmap.flush()?;
+
             // Manually sync each file in Windows since sync-ing cannot be done for the whole directory.
             #[cfg(target_os = "windows")]
             {
-                mmap.flush()?;
                 file.sync_all()?;
             }
         };


### PR DESCRIPTION
Apparently, closing file is not enough to ensure that the magic header numbers are flushed to the disk.

As man page said:

> A successful close does not guarantee that the data has been successfully saved to disk, as the kernel defers writes.

This is the only way I see how the issue like that could happen https://github.com/qdrant/qdrant/issues/1735

