### PR TITLE
Update Cargo.toml, specify license and other things

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wal"
 version = "0.1.2"
 authors = ["Dan Burkert <dan@danburkert.com>", "Andrey Vasnetsov <andrey@vasnetsov.com>"]
+license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "wal"
 version = "0.1.2"
-authors = ["Dan Burkert <dan@danburkert.com>", "Andrey Vasnetsov <andrey@vasnetsov.com>"]
+authors = [
+    "Dan Burkert <dan@danburkert.com>",
+    "Andrey Vasnetsov <andrey@vasnetsov.com>",
+    "Qdrant Team <info@qdrant.tech>",
+]
 license = "Apache-2.0"
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ authors = [
     "Qdrant Team <info@qdrant.tech>",
 ]
 license = "Apache-2.0"
+readme = "README.md"
+homepage = "https://qdrant.tech/"
+repository = "https://github.com/qdrant/wal"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
This updates the `Cargo.toml` definitions to specify the usage of Apache 2.0 in SPDX format.

Follow-up of: https://github.com/qdrant/wal/pull/50
Recommended by: https://github.com/qdrant/wal/issues/49#issuecomment-1557650475

Along with it this also:
- updates the authors list
- adds README, homepage and repository links