### PR TITLE
Calculate CRC32C using SIMD acceleration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 byteorder = "1.4"
-crc32c = "0.6.4"
+crc32c = { git = "https://github.com/lizhanhui/crc32c.git", branch = "master", default-features = false }
 log = "0.4"
 memmap2 = "0.9.0"
 rand = "0.8.5"
@@ -42,3 +42,7 @@ criterion = "0.5.1"
 [[bench]]
 name = "benchmark"
 harness = false
+
+[features]
+default = ["simd"]
+simd = ["crc32c/x86_64", "crc32c/aarch64"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 byteorder = "1.4"
-crc = "3"
+crc32c = "0.6.4"
 log = "0.4"
 memmap2 = "0.9.0"
 rand = "0.8.5"
@@ -31,8 +31,14 @@ env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
+crc = "3"
 hdrhistogram = "7.5.2"
 quickcheck = "1.0.3"
 regex = "1.8.1"
 tempfile = "3.5.0"
 chrono = "0.4.31"
+criterion = "0.5.1"
+
+[[bench]]
+name = "benchmark"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 byteorder = "1.4"
-crc32c = { git = "https://github.com/lizhanhui/crc32c.git", branch = "master", default-features = false }
+crc32c = "0.6.4"
 log = "0.4"
 memmap2 = "0.9.0"
 rand = "0.8.5"
@@ -42,7 +42,3 @@ criterion = "0.5.1"
 [[bench]]
 name = "benchmark"
 harness = false
-
-[features]
-default = ["simd"]
-simd = ["crc32c/x86_64", "crc32c/aarch64"]

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,0 +1,50 @@
+use crc::{Crc, CRC_32_ISCSI};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::{rngs::OsRng, RngCore};
+
+pub const CASTAGNOLI: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
+
+pub fn criterion_benchmark_4k(c: &mut Criterion) {
+    let mut buffer = [0u8; 8192];
+    OsRng.fill_bytes(&mut buffer);
+
+    let mut group = c.benchmark_group("8k");
+    group.throughput(criterion::Throughput::Bytes(8192));
+    group.bench_function("crc", |b| {
+        b.iter(|| {
+            let mut digest = CASTAGNOLI.digest();
+            digest.update(&buffer);
+            black_box(digest.finalize());
+        })
+    });
+
+    group.bench_function("crc32c", |b| {
+        b.iter(|| {
+            black_box(crc32c::crc32c(&buffer));
+        })
+    });
+}
+
+pub fn criterion_benchmark_1024k(c: &mut Criterion) {
+    let mut buffer = [0u8; 1048576];
+    OsRng.fill_bytes(&mut buffer);
+
+    let mut group = c.benchmark_group("1M");
+    group.throughput(criterion::Throughput::Bytes(1048576));
+    group.bench_function("crc", |b| {
+        b.iter(|| {
+            let mut digest = CASTAGNOLI.digest();
+            digest.update(&buffer);
+            black_box(digest.finalize());
+        })
+    });
+
+    group.bench_function("crc32c", |b| {
+        b.iter(|| {
+            black_box(crc32c::crc32c(&buffer));
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark_4k, criterion_benchmark_1024k);
+criterion_main!(benches);

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -2,7 +2,6 @@ use log::{debug, error, log_enabled, trace};
 use std::cmp::Ordering;
 use std::fmt;
 use std::fs::{self, OpenOptions};
-use std::hash::Hasher;
 use std::io::{Error, ErrorKind, Result};
 use std::mem;
 use std::ops::Deref;


### PR DESCRIPTION
This pull request contains two sections: one benchmark and modification to replace crate `crc` with crc32c.

A typical micro-bench run shows the following metrics
![image](https://github.com/qdrant/wal/assets/641819/1e1f6aaf-2f62-42d9-a978-253f1e9e80dc)
