### PR TITLE
Copy wal files using memcpy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,7 +489,12 @@ impl Wal {
         let close_segment_files: HashMap<_, _> = self
             .closed_segments
             .iter()
-            .map(|segment| (segment.segment.path().file_name().unwrap(), &segment.segment))
+            .map(|segment| {
+                (
+                    segment.segment.path().file_name().unwrap(),
+                    &segment.segment,
+                )
+            })
             .collect();
 
         for entry in fs::read_dir(self.path())? {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ impl Wal {
         // Validate the closed segments. They must be non-overlapping, and contiguous.
         closed_segments.sort_by(|a, b| a.start_index.cmp(&b.start_index));
         let mut next_start_index = closed_segments
-            .get(0)
+            .first()
             .map_or(0, |segment| segment.start_index);
         for &ClosedSegment {
             start_index,
@@ -394,7 +394,7 @@ impl Wal {
         if until
             <= self
                 .closed_segments
-                .get(0)
+                .first()
                 .map_or(0, |segment| segment.start_index)
         {
             // Do nothing, the first entry is already greater than `until`.
@@ -450,7 +450,7 @@ impl Wal {
         self.open_segment_start_index()
             - self
                 .closed_segments
-                .get(0)
+                .first()
                 .map_or(0, |segment| segment.start_index)
             + self.open_segment.segment.len() as u64
     }
@@ -458,7 +458,7 @@ impl Wal {
     /// The index of the first entry.
     pub fn first_index(&self) -> u64 {
         self.closed_segments
-            .get(0)
+            .first()
             .map_or(0, |segment| segment.start_index)
     }
 
@@ -523,7 +523,7 @@ impl fmt::Debug for Wal {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let start_index = self
             .closed_segments
-            .get(0)
+            .first()
             .map_or(0, |segment| segment.start_index);
         let end_index = self.open_segment_start_index() + self.open_segment.segment.len() as u64;
         write!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -471,6 +471,18 @@ impl Wal {
     pub fn clear(&mut self) -> Result<()> {
         self.truncate(self.first_index())
     }
+
+    /// copy all files to the given path directory
+    pub fn save_to_path<P>(&self, path: P) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        self.open_segment.segment.save_to_path(&path)?;
+        for segment in &self.closed_segments {
+            segment.segment.save_to_path(&path)?;
+        }
+        Ok(())
+    }
 }
 
 impl fmt::Debug for Wal {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use crossbeam_channel::{Receiver, Sender};
 use fs4::FileExt;
 use log::{debug, info, trace, warn};
 use std::cmp::Ordering;
+use std::collections::HashMap;
 use std::fmt;
 use std::fs::{self, File};
 use std::io::{Error, ErrorKind, Result};
@@ -472,14 +473,42 @@ impl Wal {
         self.truncate(self.first_index())
     }
 
-    /// copy all files to the given path directory
-    pub fn save_to_path<P>(&self, path: P) -> Result<()>
+    /// Copy all files to the given path directory. directory should exist and be empty
+    pub fn copy_to_path<P>(&self, path: P) -> Result<()>
     where
         P: AsRef<Path>,
     {
-        self.open_segment.segment.save_to_path(&path)?;
-        for segment in &self.closed_segments {
-            segment.segment.save_to_path(&path)?;
+        if fs::read_dir(path.as_ref())?.next().is_some() {
+            return Err(Error::new(
+                ErrorKind::AlreadyExists,
+                format!("path {:?} not empty", path.as_ref()),
+            ));
+        };
+
+        let open_segment_file = self.open_segment.segment.path().file_name().unwrap();
+        let close_segment_files: HashMap<_, _> = self
+            .closed_segments
+            .iter()
+            .map(|segment| (segment.segment.path().file_name().unwrap(), &segment.segment))
+            .collect();
+
+        for entry in fs::read_dir(self.path())? {
+            let entry = entry?;
+            if !entry.metadata()?.is_file() {
+                continue;
+            }
+
+            // if file is locked by any Segment, call copy_to_path on it
+            let entry_file_name = entry.file_name();
+            let dst_path = path.as_ref().to_owned().join(entry_file_name.clone());
+            if entry_file_name == open_segment_file {
+                self.open_segment.segment.copy_to_path(&dst_path)?;
+            } else if let Some(segment) = close_segment_files.get(entry_file_name.as_os_str()) {
+                segment.copy_to_path(&dst_path)?;
+            } else {
+                // if file is not locked by any Segment, just copy it
+                fs::copy(&entry.path(), &dst_path)?;
+            }
         }
         Ok(())
     }

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -644,13 +644,11 @@ impl Segment {
         }
     }
 
-    pub fn save_to_path<P>(&self, path: P) -> Result<()>
+    pub(crate) fn copy_to_path<P>(&self, path: P) -> Result<()>
     where
         P: AsRef<Path>,
     {
-        let file_name = self.path.file_name().unwrap();
-        let dst_path = path.as_ref().to_owned().join(file_name);
-        let mut other = Self::create(dst_path, self.capacity())?;
+        let mut other = Self::create(path, self.capacity())?;
         unsafe {
             other
                 .mmap

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -648,6 +648,13 @@ impl Segment {
     where
         P: AsRef<Path>,
     {
+        if path.as_ref().exists() {
+            return Err(Error::new(
+                ErrorKind::AlreadyExists,
+                format!("Path {:?} already exists", path.as_ref()),
+            ));
+        }
+
         let mut other = Self::create(path, self.capacity())?;
         unsafe {
             other

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -643,6 +643,22 @@ impl Segment {
             }
         }
     }
+
+    pub fn save_to_path<P>(&self, path: P) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        let file_name = self.path.file_name().unwrap();
+        let dst_path = path.as_ref().to_owned().join(file_name);
+        let mut other = Self::create(dst_path, self.capacity())?;
+        unsafe {
+            other
+                .mmap
+                .as_mut_slice()
+                .copy_from_slice(self.mmap.as_slice());
+        }
+        Ok(())
+    }
 }
 
 impl fmt::Debug for Segment {


### PR DESCRIPTION
Fix of https://github.com/qdrant/qdrant/issues/2620 on WAL side.

Avoid copy file as `fs::copy` when mmap is locked by segment. Copying is implemented as new file creation and `memcpy` over all data. More detailed description why we need such copy you can find here:
https://github.com/qdrant/wal/pull/64