### PR TITLE
Improve readability of `prefix_truncate`

### DIFF
--- a/src/segment.rs
+++ b/src/segment.rs
@@ -152,6 +152,7 @@ impl Segment {
                 .read(true)
                 .write(true)
                 .create(true)
+                .truncate(true)
                 .open(&tmp_file_path)?;
 
             // fs4 provides some cross-platform bindings which help for Windows.


### PR DESCRIPTION
I find our current `prefix_truncate` function hard to read and make sense of.

In this PR I've restructured it in an attempt to make it better readable. It also removes an unnecessary and unreachable if-statement.

Before, I thought this function had a fatal flaw, but this actually does not seem to be the case. I did keep the changes I made for readability, which is the result of this PR.