### PR TITLE
crc32c 0.6.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 byteorder = "1.4"
-crc32c = "0.6.4"
+crc32c = "0.6.5"
 log = "0.4"
 memmap2 = "0.9.0"
 rand = "0.8.5"


### PR DESCRIPTION
I tried to compile qdrant in nightly but it failed because of:

```
error[E0635]: unknown feature `stdsimd`
  --> /home/agourlay/.cargo/registry/src/index.crates.io-6f17d22bba15001f/crc32c-0.6.4/src/lib.rs:23:30
   |
23 | #![cfg_attr(nightly, feature(stdsimd))]
   |
```

This has been fixed in 0.6.5.