### PR TITLE
Update criterion dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ quickcheck = "1.0.3"
 regex = "1.10.6"
 tempfile = "3.12.0"
 chrono = "0.4.38"
-criterion = "0.5.1"
+criterion = "0.6.0"
 
 [[bench]]
 name = "benchmark"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,6 +1,7 @@
 use crc::{CRC_32_ISCSI, Crc};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 use rand::RngCore;
+use std::hint::black_box;
 
 pub const CASTAGNOLI: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
 


### PR DESCRIPTION
Changed ```criterion::black_box``` (deprecated) to ```std::hint::black_box``` (Now used)