### PR TITLE
Apply clippy auto fix for string formatting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,12 +238,12 @@ impl Wal {
             path,
             flush: None,
         };
-        info!("{:?}: opened", wal);
+        info!("{wal:?}: opened");
         Ok(wal)
     }
 
     fn retire_open_segment(&mut self) -> Result<()> {
-        trace!("{:?}: retiring open segment", self);
+        trace!("{self:?}: retiring open segment");
         let mut segment = self.creator.next()?;
         mem::swap(&mut self.open_segment, &mut segment);
 
@@ -288,13 +288,13 @@ impl Wal {
     }
 
     pub fn flush_open_segment(&mut self) -> Result<()> {
-        trace!("{:?}: flushing open segments", self);
+        trace!("{self:?}: flushing open segments");
         self.open_segment.segment.flush()?;
         Ok(())
     }
 
     pub fn flush_open_segment_async(&mut self) -> thread::JoinHandle<Result<()>> {
-        trace!("{:?}: flushing open segments", self);
+        trace!("{self:?}: flushing open segments");
         self.open_segment.segment.flush_async()
     }
 
@@ -329,7 +329,7 @@ impl Wal {
     /// but the truncated entries are not guaranteed to be removed until the
     /// wal is flushed.
     pub fn truncate(&mut self, from: u64) -> Result<()> {
-        trace!("{:?}: truncate from entry {}", self, from);
+        trace!("{self:?}: truncate from entry {from}");
         let open_start_index = self.open_segment_start_index();
         if from >= open_start_index {
             self.open_segment
@@ -641,7 +641,7 @@ impl Drop for SegmentCreator {
         drop(self.rx.take());
         if let Some(join_handle) = self.thread.take() {
             if let Err(error) = join_handle.join() {
-                warn!("Error while shutting down segment creator: {:?}", error);
+                warn!("Error while shutting down segment creator: {error:?}");
             }
         }
     }
@@ -1030,8 +1030,7 @@ mod test {
         init_logger();
         fn prefix_truncate(entry_count: u8, until: u8) -> TestResult {
             trace!(
-                "prefix truncate; entry_count: {}, until: {}",
-                entry_count, until
+                "prefix truncate; entry_count: {entry_count}, until: {until}"
             );
             if until > entry_count {
                 return TestResult::discard();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1029,9 +1029,7 @@ mod test {
     fn check_prefix_truncate() {
         init_logger();
         fn prefix_truncate(entry_count: u8, until: u8) -> TestResult {
-            trace!(
-                "prefix truncate; entry_count: {entry_count}, until: {until}"
-            );
+            trace!("prefix truncate; entry_count: {entry_count}, until: {until}");
             if until > entry_count {
                 return TestResult::discard();
             }

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -271,9 +271,7 @@ impl Segment {
                     LittleEndian::read_u32(&segment[offset + HEADER_LEN + padded_len..]);
                 if entry_crc != stored_crc {
                     if stored_crc != 0 {
-                        log::warn!(
-                            "CRC mismatch at offset {offset}: {entry_crc} != {stored_crc}"
-                        );
+                        log::warn!("CRC mismatch at offset {offset}: {entry_crc} != {stored_crc}");
                     }
                     break;
                 }

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -203,7 +203,7 @@ impl Segment {
             crc: seed,
             flush_offset: 0,
         };
-        debug!("{:?}: created", segment);
+        debug!("{segment:?}: created");
         Ok(segment)
     }
 
@@ -272,10 +272,7 @@ impl Segment {
                 if entry_crc != stored_crc {
                     if stored_crc != 0 {
                         log::warn!(
-                            "CRC mismatch at offset {}: {} != {}",
-                            offset,
-                            entry_crc,
-                            stored_crc
+                            "CRC mismatch at offset {offset}: {entry_crc} != {stored_crc}"
                         );
                     }
                     break;
@@ -294,7 +291,7 @@ impl Segment {
             crc,
             flush_offset: 0,
         };
-        debug!("{:?}: opened", segment);
+        debug!("{segment:?}: opened");
         Ok(segment)
     }
 
@@ -388,11 +385,11 @@ impl Segment {
         if from >= self.index.len() {
             return;
         }
-        trace!("{:?}: truncating from position {}", self, from);
+        trace!("{self:?}: truncating from position {from}");
 
         // Remove the index entries.
         let deleted = self.index.drain(from..).count();
-        trace!("{:?}: truncated {} entries", self, deleted);
+        trace!("{self:?}: truncated {deleted} entries");
 
         // Update the CRC.
         if self.index.is_empty() {
@@ -410,18 +407,18 @@ impl Segment {
 
     /// Flushes recently written entries to durable storage.
     pub fn flush(&mut self) -> Result<()> {
-        trace!("{:?}: flushing", self);
+        trace!("{self:?}: flushing");
         let start = self.flush_offset;
         let end = self.size();
 
         match start.cmp(&end) {
             Ordering::Equal => {
-                trace!("{:?}: nothing to flush", self);
+                trace!("{self:?}: nothing to flush");
                 Ok(())
             } // nothing to flush
             Ordering::Less => {
                 // flush new elements added since last flush
-                trace!("{:?}: flushing byte range [{}, {})", self, start, end);
+                trace!("{self:?}: flushing byte range [{start}, {end})");
                 let mut view = unsafe { self.mmap.clone() };
                 self.flush_offset = end;
                 view.restrict(start, end - start)?;
@@ -430,7 +427,7 @@ impl Segment {
             Ordering::Greater => {
                 // most likely truncated in between flushes
                 // register new flush offset & flush the whole segment
-                trace!("{:?}: flushing after truncation", self);
+                trace!("{self:?}: flushing after truncation");
                 let view = unsafe { self.mmap.clone() };
                 self.flush_offset = end;
                 view.flush()
@@ -440,7 +437,7 @@ impl Segment {
 
     /// Flushes recently written entries to durable storage.
     pub fn flush_async(&mut self) -> thread::JoinHandle<Result<()>> {
-        trace!("{:?}: async flushing", self);
+        trace!("{self:?}: async flushing");
         let start = self.flush_offset;
         let end = self.size();
 
@@ -461,7 +458,7 @@ impl Segment {
                 };
 
                 thread::spawn(move || {
-                    trace!("{}", log_msg);
+                    trace!("{log_msg}");
                     view.restrict(start, end - start).and_then(|_| view.flush())
                 })
             }
@@ -478,7 +475,7 @@ impl Segment {
                 };
 
                 thread::spawn(move || {
-                    trace!("{}", log_msg);
+                    trace!("{log_msg}");
                     view.flush()
                 })
             }
@@ -495,7 +492,7 @@ impl Segment {
         // Sanity check the 8-byte alignment invariant.
         assert_eq!(required_capacity & !7, required_capacity);
         if required_capacity > self.capacity() {
-            debug!("{:?}: resizing to {} bytes", self, required_capacity);
+            debug!("{self:?}: resizing to {required_capacity} bytes");
             self.flush()?;
             let file = OpenOptions::new()
                 .read(true)
@@ -575,7 +572,7 @@ impl Segment {
 
     /// Deletes the segment file.
     pub fn delete(self) -> Result<()> {
-        debug!("{:?}: deleting file", self);
+        debug!("{self:?}: deleting file");
 
         #[cfg(not(target_os = "windows"))]
         {
@@ -591,7 +588,7 @@ impl Segment {
     #[cfg(not(target_os = "windows"))]
     fn delete_unix(self) -> Result<()> {
         fs::remove_file(&self.path).map_err(|e| {
-            error!("{:?}: failed to delete segment {}", self, e);
+            error!("{self:?}: failed to delete segment {e}");
             e
         })
     }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -40,7 +40,7 @@ impl EntryGenerator {
     }
 
     pub fn with_seed_and_segment_capacity(seed: usize, size: usize) -> EntryGenerator {
-        info!("Creating EntryGenerator with seed {}", seed);
+        info!("Creating EntryGenerator with seed {seed}");
         EntryGenerator {
             seed,
             rng: rand::rngs::StdRng::seed_from_u64(seed as u64),


### PR DESCRIPTION
Ran:
```sh
cargo clippy --all-targets --fix -- -D warnings 
```