### PR TITLE
Add new param to retain more closed segments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1174,8 +1174,9 @@ mod test {
 
             // Generalized logic
             let segments_that_can_be_truncated = truncate_index / entries_per_segment;
-            let expected_closed_segments =
-                (initial_closed_segments - segments_that_can_be_truncated as usize).max(1);
+            let expected_closed_segments = (initial_closed_segments
+                - segments_that_can_be_truncated as usize)
+                .max(retain_closed);
             let expected_trimmed_until =
                 (initial_closed_segments - expected_closed_segments) as u64 * entries_per_segment;
 


### PR DESCRIPTION
Whenever we are doing `prefix_truncate()` in the wal, we can preserve more closed segments. The current value is 1 (implicit) and hence kept it as default for backwards compatibility. 

The advantage is that it can make it more likely to use wal delta transfer over streaming records which is faster than the latter. 