### PR TITLE
Add test for prefix truncation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1103,37 +1103,6 @@ mod test {
         }
     }
 
-    fn viz_wal(wal: &Wal, kind: &str) {
-        let wal_size = 15.max(wal.num_entries()) as usize;
-        let mut bits = vec![None; wal_size];
-        for i in (wal.first_index() as usize)..=(wal.last_index() as usize) {
-            // for i in 0..wal_size {
-            bits[i] = wal
-                .entry(i as u64)
-                .is_some()
-                .then_some(true)
-                .or_else(|| Some(false));
-        }
-
-        // viz the values in ascii style table format:
-        let mut viz = String::new();
-        viz.push_str("Index: ");
-        for i in 0..wal_size {
-            viz.push_str(&format!("{:2} ", i));
-        }
-        viz.push('\n');
-        viz.push_str("Value: ");
-        for bit in &bits {
-            match bit {
-                Some(true) => viz.push_str(" 1 "),
-                Some(false) => viz.push_str(" 0 "),
-                None => viz.push_str(" - "),
-            }
-        }
-        viz.push('\n');
-        info!("Visualization of entries {kind} prefix truncation:\n{viz}");
-    }
-
     #[test]
     fn test_prefix_truncate() {
         init_logger();
@@ -1160,12 +1129,8 @@ mod test {
 
             assert_eq!(wal.closed_segments.len(), 4);
 
-            viz_wal(&wal, "before");
-
             // Do the prefix truncation
             wal.prefix_truncate(truncate_index).unwrap();
-
-            viz_wal(&wal, "after");
 
             // truncated_index shouldn't be gone while entries before it should be gone
             assert!(wal.entry(truncate_index).is_some());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1112,43 +1112,44 @@ mod test {
         let mut wal = Wal::with_options(
             dir.path(),
             &WalOptions {
-                segment_capacity: 4096, // >= 2 * 2000 bytes. So each segment can hold > 2 entry
+                segment_capacity: 4096,
                 segment_queue_len: 3,
             },
         )
         .unwrap();
 
+        let entries_per_segment = 2; // Based on segment_capacity / entry_size
+
         for truncate_index in 0..num_entries {
             assert!(wal.entry(0).is_none());
             for i in 0..num_entries {
-                // insert the same entry num_entries times
                 assert_eq!(i, wal.append(&&entry[..]).unwrap());
             } // for num_entries=10 => 4 closed segments + 1 open segment (each having 2 entries)
 
-            assert_eq!(wal.closed_segments.len(), 4);
+            let initial_closed_segments = wal.closed_segments.len();
 
             // Do the prefix truncation
             wal.prefix_truncate(truncate_index).unwrap();
 
-            // truncated_index shouldn't be gone while entries in previous segments
-            assert!(wal.entry(truncate_index).is_some());
-            let expected_trimmed_until = if truncate_index > 6 {
-                num_entries - 4 // 4 comes from 1 closed segment + 1 open segment that must remain (each having 2 entries)
-            } else if truncate_index % 2 == 0 {
-                truncate_index.saturating_sub(1) // even index => odd position => prev segment is at current - 1
-            } else {
-                truncate_index.saturating_sub(2) // odd index => even position => prev segment is at current - 2
-            };
-            for i in (0..expected_trimmed_until).rev() {
-                trace!("truncate_index: {truncate_index} i: {i}");
+            // Generalized logic
+            let segments_that_can_be_truncated = truncate_index / entries_per_segment;
+            let expected_closed_segments =
+                (initial_closed_segments - segments_that_can_be_truncated as usize).max(1);
+            let expected_trimmed_until =
+                (initial_closed_segments - expected_closed_segments) as u64 * entries_per_segment;
+
+            assert!(wal.entry(truncate_index).is_some()); // truncate_index should be intact
+
+            for i in 0..expected_trimmed_until { // before should be trimmed
                 assert!(wal.entry(i).is_none());
             }
-            assert_eq!(
-                wal.closed_segments.len(),
-                (4 - (truncate_index / 2) as usize).max(1) // leave at least one closed segment
-            );
 
-            wal.truncate(0).unwrap(); // Delete all entries after each test case
+            for i in expected_trimmed_until..num_entries { // after should be intact
+                assert!(wal.entry(i).is_some());
+            }
+
+            assert_eq!(wal.closed_segments.len(), expected_closed_segments);
+            wal.truncate(0).unwrap(); // Clean up for the next test case
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1103,7 +1103,6 @@ mod test {
         }
     }
 
-
     #[test]
     fn test_prefix_truncate() {
         init_logger();
@@ -1119,10 +1118,12 @@ mod test {
         )
         .unwrap();
 
-        for truncate_index in 0..10 { // each item is a test case
+        for truncate_index in 0..10 {
+            // each item is a test case
             info!("truncate_index: {truncate_index}");
             assert!(wal.entry(0).is_none());
-            for i in 0..10 { // insert the same entry 10 times
+            for i in 0..10 {
+                // insert the same entry 10 times
                 assert_eq!(i, wal.append(&&entry[..]).unwrap());
             } // this should generate 4 closed segments with 2 entries each, while writing remaining data (96 bytes) to the open segment
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1140,11 +1140,13 @@ mod test {
 
             assert!(wal.entry(truncate_index).is_some()); // truncate_index should be intact
 
-            for i in 0..expected_trimmed_until { // before should be trimmed
+            for i in 0..expected_trimmed_until {
+                // before should be trimmed
                 assert!(wal.entry(i).is_none());
             }
 
-            for i in expected_trimmed_until..num_entries { // after should be intact
+            for i in expected_trimmed_until..num_entries {
+                // after should be intact
                 assert!(wal.entry(i).is_some());
             }
 


### PR DESCRIPTION
We only had a dedicated test for `truncate()` but not `prefix_truncate()`

While `prefix_truncate()` only had an automated property test called `check_prefix_truncate()`
